### PR TITLE
Add hashFrame zero-copy hex & golden tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## v0.4.0-alpha
+
+- Refactored `hashFrame` to use zero-copy hex encoding via `bytesToHex` from `@noble/hashes`.
+- Added golden-vector tests for `hashFrame`.
+- Protocol hash changed; old network snapshots are incompatible.

--- a/src/core/entity.ts
+++ b/src/core/entity.ts
@@ -3,13 +3,14 @@ import type {
   ProposedFrame, Address, Hex, TS
 } from '../types';
 import { keccak_256 as keccak } from '@noble/hashes/sha3';
+import { bytesToHex } from '@noble/hashes/utils';
 import { verifyAggregate } from '../crypto/bls';
 import { encFrame } from '../codec/rlp';
 
 /* ──────────── frame hashing ──────────── */
 /** Compute canonical hash of a frame using keccak256(RLP(frame)). */
 export const hashFrame = (f: Frame<EntityState>): Hex =>
-  ('0x' + Buffer.from(keccak(encFrame(f))).toString('hex')) as Hex;
+  ('0x' + bytesToHex(keccak(encFrame(f)))) as Hex;
 
 /* ──────────── internal helpers ──────────── */
 const sortTx = (a: Transaction, b: Transaction) =>

--- a/tests/hashFrame.spec.ts
+++ b/tests/hashFrame.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { hashFrame } from '../src/core/entity'
+import { mkFrame } from './helpers/frame'
+import { createChatTx } from './helpers/tx'
+import type { Address } from '../src/types'
+
+describe('hashFrame golden vectors', () => {
+  it('empty frame ts=1', () => {
+    const f = mkFrame({ ts: 1 })
+    const h = hashFrame(f as any)
+    expect(h).toBe('0x6cca6ca84fc54588ffa69fb4f3f21c88baabf96c2ff6cef81f374cbb87ab6c63')
+  })
+
+  it('height=1 ts=2', () => {
+    const f = mkFrame({ height: 1n, ts: 2 })
+    const h = hashFrame(f as any)
+    expect(h).toBe('0xad4562327f0448145684a81229820ca89a6b8c50f07bc44c40a64b76f088ba1b')
+  })
+
+  it('single chat tx', () => {
+    const tx = createChatTx('0x01' as Address, 'hi')
+    const f = mkFrame({ txs: [tx], ts: 3 })
+    const h = hashFrame(f as any)
+    expect(h).toBe('0x090aa4a6ea8a96654c68d98b34a6badb71f5e4ddc826b1b6ead89b5961f230d1')
+  })
+})


### PR DESCRIPTION
## Summary
- use `bytesToHex` for zero-copy conversion in `hashFrame`
- add golden vector tests for `hashFrame`
- document protocol change in `CHANGELOG`

## Testing
- `bun test tests/hashFrame.spec.ts`
- `bun test tests/runtime.e2e.test.ts`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_6864fc03c7408323ad3a9f2585a94e34