### PR TITLE
docs: align documentation with current implementation

### DIFF
--- a/docs/consensus.md
+++ b/docs/consensus.md
@@ -11,11 +11,11 @@ The consensus process follows five distinct phases:
 Any signer can inject a signed transaction into the target entity's mempool:
 
 ```typescript
-const input: Input = [
-  signerIdx,
-  entityId,
-  { type: 'addTx', tx: signedTx }
-];
+const input: Input = {
+  from: signerAddress,
+  to:   entityAddress,
+  cmd:  { type: 'ADD_TX', addrKey: 'jurisdiction:entityId', tx: signedTx }
+};
 ```
 
 **Validation**:
@@ -28,7 +28,11 @@ const input: Input = [
 The current proposer packages queued transactions into a frame:
 
 ```typescript
-{ type: 'proposeFrame' }
+const input: Input = {
+  from: proposerAddress,
+  to:   entityAddress,
+  cmd:  { type: 'PROPOSE', addrKey: 'jurisdiction:entityId', ts: Date.now() }
+};
 ```
 
 **Proposer Selection**:
@@ -40,9 +44,9 @@ The current proposer packages queued transactions into a frame:
 ```typescript
 const frame: Frame = {
   height: entity.height + 1n,
-  timestamp: BigInt(Date.now()),
-  txs: entity.mempool,
-  postState: applyTxs(entity.state, entity.mempool)
+  ts:     BigInt(Date.now()),
+  txs:    entity.mempool,
+  state:  applyTxs(entity.state, entity.mempool)
 };
 ```
 
@@ -51,7 +55,11 @@ const frame: Frame = {
 Other quorum members verify and sign the proposed frame:
 
 ```typescript
-{ type: 'signFrame', sig: signature }
+const input: Input = {
+  from: signerAddress,
+  to:   entityAddress,
+  cmd:  { type: 'SIGN', addrKey: 'jurisdiction:entityId', frameHash: hash, sig: signature }
+};
 ```
 
 **Verification Steps**:
@@ -67,11 +75,16 @@ Other quorum members verify and sign the proposed frame:
 When collected signatures meet the threshold, the proposer aggregates them:
 
 ```typescript
-{ 
-  type: 'commitFrame', 
-  frame: frame,
-  hanko: aggregateSignature  // 48-byte BLS aggregate
-}
+const input: Input = {
+  from: proposerAddress,
+  to:   entityAddress,
+  cmd:  { 
+    type: 'COMMIT', 
+    addrKey: 'jurisdiction:entityId',
+    frame: frame,
+    hanko: aggregateSignature
+  }
+};
 ```
 
 **Finality**: Once committed, the frame cannot be reversed.
@@ -80,7 +93,7 @@ When collected signatures meet the threshold, the proposer aggregates them:
 
 All replicas:
 1. Verify `hash(frame) ⟂ hanko`
-2. Adopt `postState`
+2. Adopt `state`
 3. Clear mempool
 4. Advance height
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -9,10 +9,14 @@ XLN uses a carefully designed type system that balances simplicity with expressi
 The fundamental message format for all communication:
 
 ```typescript
-export type Input = [signerIdx: number, entityId: string, cmd: Command];
+export interface Input {
+  from: Address;
+  to:   Address;
+  cmd:  Command;
+}
 ```
 
-**Implementation**: [`src/types.ts#L15`](../src/types.ts#L15)
+**Implementation**: [`src/types.ts`](../src/types.ts)
 
 ### Commands
 
@@ -20,31 +24,36 @@ Commands drive state transitions at the consensus level:
 
 ```typescript
 export type Command =
-  | { type: 'importEntity'; snapshot: EntityState }
-  | { type: 'addTx';        tx: EntityTx }
-  | { type: 'proposeFrame' }
-  | { type: 'signFrame';    sig: string }
-  | { type: 'commitFrame';  frame: Frame; hanko: string };
+  | { type: 'IMPORT';  replica: Replica }
+  | { type: 'ADD_TX';  addrKey: string; tx: Transaction }
+  | { type: 'PROPOSE'; addrKey: string; ts: TS }
+  | { type: 'SIGN';    addrKey: string; signer: Address; frameHash: Hex; sig: Hex }
+  | { type: 'COMMIT';  addrKey: string; hanko: Hanko; frame: Frame<EntityState> };
 ```
 
-**Implementation**: [`src/types.ts#L20`](../src/types.ts#L20)
+**Implementation**: [`src/types.ts`](../src/types.ts)
 
-### Entity Transaction
+### Transaction
 
 Application-level operations within an entity:
 
 ```typescript
-export type EntityTx = {
-  kind: string;     // e.g. 'chat', 'transfer'
-  data: any;        // Operation-specific payload
-  nonce: bigint;    // Per-signer replay protection
-  sig: string;      // Ed25519 signature (mocked in MVP)
-};
+export type Transaction = ChatTx; // In MVP, only 'chat' transactions exist
+
+export type ChatTx = BaseTx<'chat'> & { body: { message: string } };
+
+export interface BaseTx<K extends TxKind = TxKind> {
+  kind:  K;
+  nonce: Nonce;
+  from:  Address;
+  body:  unknown;
+  sig:   Hex;
+}
 ```
 
 **Key Properties**:
 - `kind`: Determines processing logic
-- `nonce`: Prevents replay attacks
+- `nonce`: Per-signer replay protection
 - `sig`: Ensures authenticity
 
 ### Frame
@@ -52,32 +61,25 @@ export type EntityTx = {
 The entity-level block structure:
 
 ```typescript
-export type Frame = {
-  height: bigint;
-  timestamp: bigint;
-  txs: EntityTx[];
-  postState: EntityState;
+export interface Frame<T = unknown> {
+  height: UInt64;
+  ts:     TS;
+  txs:    Transaction[];
+  state:  T;
 };
 ```
 
-**Design Note**: Including `postState` in the frame enables instant verification without replay.
+**Design Note**: Including `state` in the frame enables instant verification without replay. The hash of the frame includes this state, ensuring deterministic validation.
 
 ### Entity State
 
 Complete state of an autonomous entity:
 
 ```typescript
-export type EntityState = {
-  height: bigint;
+export interface EntityState {
   quorum: Quorum;
-  signerRecords: Record<string, { nonce: bigint }>;
-  domainState: any;       // Application-specific (chat log, balances, etc.)
-  mempool: EntityTx[];
-  proposal?: { 
-    frame: Frame; 
-    sigs: Record<string, string> 
-  };
-};
+  chat:   { from: Address; msg: string; ts: TS }[];
+}
 ```
 
 ### Quorum Definition

--- a/docs/hashing.md
+++ b/docs/hashing.md
@@ -28,25 +28,21 @@ export function hash(data: Uint8Array): string {
 Frames are hashed deterministically:
 
 ```typescript
+export const encFrame = (f: Frame<EntityState>): Uint8Array =>
+  rlp.encode([
+    bnToBuf(f.height),
+    f.ts,
+    f.txs.map(encTx) as any,
+    encEntityState(f.state),
+  ]) as Uint8Array;
+
 export function hashFrame(frame: Frame): string {
-  // Canonical encoding order
-  const encoded = RLP.encode([
-    frame.height,
-    frame.timestamp,
-    frame.txs.map(tx => [
-      tx.kind,
-      tx.data,
-      tx.nonce,
-      tx.sig
-    ]),
-    // Note: postState excluded from hash
-  ]);
-  
-  return hash(encoded);
+  const encoded = encFrame(frame);
+  return '0x' + bytesToHex(keccak256(encoded));
 }
 ```
 
-**Design Choice**: `postState` is excluded from the hash to allow validators to verify execution independently.
+**Design Choice**: `state` is included in the hash. This enforces that all validators agree on the exact same state transition and resulting state, making validation a simple hash comparison rather than requiring re-execution.
 
 ## Merkle Tree Construction
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,5 +1,7 @@
 # Persistence
 
+> **Note**: The persistence layer described here is a **roadmap item** and is **not yet implemented** in the `main` branch. The current implementation uses an in-memory `Map` for state management.
+
 XLN implements a sophisticated storage architecture optimized for crash recovery, deterministic replay, and audit-grade history.
 
 ## Storage Architecture


### PR DESCRIPTION
The existing documentation was out of sync with the current codebase. This commit updates the documentation to reflect the following changes:

- The wire format for  is now an object envelope, not a tuple.
- Command tags are now all-caps (e.g.,  instead of ).
- The  hash now includes the  field.
- The LevelDB/WAL persistence layer is marked as a roadmap item, as it is not yet implemented.

These changes bring the documentation back in line with the  branch, reducing confusion for contributors and consumers of the spec.