### PR TITLE
Refactor runtime and commands; add prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "singleQuote": true,
-  "semi": false,
-  "printWidth": 100
-}

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  semi: true,
+  singleQuote: true,
+  printWidth: 90,
+  trailingComma: 'all',
+}

--- a/src/core/bls.ts
+++ b/src/core/bls.ts
@@ -1,10 +1,13 @@
-import * as nobleBls from '@noble/bls12-381'
+import * as nobleBls from '@noble/bls12-381';
 
 /**
  * Sign arbitrary bytes with a 32-byte secret key.
  */
-export async function sign(message: Uint8Array, privKey: Uint8Array): Promise<Uint8Array> {
-  return nobleBls.sign(message, privKey)
+export async function sign(
+  message: Uint8Array,
+  privKey: Uint8Array,
+): Promise<Uint8Array> {
+  return nobleBls.sign(message, privKey);
 }
 
 /**
@@ -16,6 +19,6 @@ export async function verifyAggregate(
   msgs: Uint8Array[],
   pubs: Uint8Array[],
 ): Promise<boolean> {
-  if (msgs.length === 0 || msgs.length !== pubs.length) return false
-  return nobleBls.verifyBatch(sig, msgs, pubs)
+  if (msgs.length === 0 || msgs.length !== pubs.length) return false;
+  return nobleBls.verifyBatch(sig, msgs, pubs);
 }

--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -1,0 +1,121 @@
+import { verifyAggregate } from './bls';
+import { getSender, hashEntityState, hashFrame, sortTransactions } from './hash';
+import type {
+  Address,
+  Command,
+  EntityState,
+  EntityTx,
+  Frame,
+  FrameHeader,
+  Result,
+} from './types';
+
+export const addTx = (
+  state: EntityState,
+  cmd: Extract<Command, { type: 'addTx' }>,
+): Result<EntityState> => {
+  const signer = cmd.tx.sig.slice(0, 42) as Address;
+  const last = state.signerRecords[signer]?.nonce ?? 0n;
+  if (cmd.tx.nonce !== last + 1n) return { ok: false, error: 'nonce-out-of-order' };
+  return {
+    ok: true,
+    value: {
+      ...state,
+      mempool: [...state.mempool, cmd.tx],
+      signerRecords: { ...state.signerRecords, [signer]: { nonce: cmd.tx.nonce } },
+    },
+  };
+};
+
+export const proposeFrame = (
+  state: EntityState,
+  cmd: Extract<Command, { type: 'proposeFrame' }>,
+): { state: EntityState; frame: Frame } => {
+  const txs = sortTransactions(state.mempool);
+  const postStateRoot = hashEntityState({ ...state, mempool: [] });
+  const frame: Frame = { ...cmd.header, txs, postStateRoot };
+  return { state: { ...state, proposal: { frame, sigs: {} } }, frame };
+};
+
+export const signFrame = (
+  state: EntityState,
+  cmd: Extract<Command, { type: 'signFrame' }>,
+): Result<EntityState> => {
+  if (!state.proposal) return { ok: false, error: 'no-proposal' };
+  const addr = cmd.sig.slice(0, 42) as Address;
+  if (state.proposal.sigs[addr]) return { ok: false, error: 'dup-sig' };
+  const nonce = (state.signerRecords[addr]?.nonce ?? 0n) + 1n;
+  return {
+    ok: true,
+    value: {
+      ...state,
+      signerRecords: { ...state.signerRecords, [addr]: { nonce } },
+      proposal: { ...state.proposal, sigs: { ...state.proposal.sigs, [addr]: cmd.sig } },
+    },
+  };
+};
+
+const effectiveWeight = (
+  votes: ReadonlyArray<{ signer: string }>,
+  weightMap: Record<string, bigint>,
+): bigint => {
+  const seen = new Set<string>();
+  let total = 0n;
+  for (const v of votes) {
+    if (seen.has(v.signer)) continue;
+    seen.add(v.signer);
+    total += weightMap[v.signer] ?? 0n;
+  }
+  return total;
+};
+
+export const commitFrame = async (
+  state: EntityState,
+  cmd: Extract<Command, { type: 'commitFrame' }>,
+): Promise<Result<EntityState>> => {
+  const { proposal } = state;
+  if (!proposal) return { ok: false, error: 'no-proposal' };
+
+  const weightMap = Object.fromEntries(
+    state.quorum.members.map((m) => [m.address, m.shares]),
+  ) as Record<string, bigint>;
+  const votes = Object.keys(proposal.sigs).map((signer) => ({ signer }));
+  if (effectiveWeight(votes, weightMap) < state.quorum.threshold)
+    return { ok: false, error: 'quorum-not-reached' };
+
+  const frameHash = hashFrame(cmd.frame);
+  if (!(await verifyAggregate(cmd.hanko, [frameHash], [])))
+    return { ok: false, error: 'invalid-agg-sig' };
+
+  let newDomainState = state.domainState;
+  const newSignerRecords = { ...state.signerRecords };
+
+  const domainReducers: Record<string, (s: unknown, tx: EntityTx) => unknown> = {
+    chat: (s, tx) => ({
+      ...(s as { chat?: Array<{ from: string; msg: string }> }),
+      chat: [
+        ...((s as { chat?: Array<{ from: string; msg: string }> }).chat ?? []),
+        { from: getSender(tx), msg: (tx.data as { msg: string }).msg },
+      ],
+    }),
+  };
+
+  for (const tx of cmd.frame.txs) {
+    const reducer = domainReducers[tx.kind];
+    if (reducer) newDomainState = reducer(newDomainState, tx);
+    const sender = getSender(tx);
+    newSignerRecords[sender] = { nonce: tx.nonce };
+  }
+
+  return {
+    ok: true,
+    value: {
+      ...state,
+      height: cmd.frame.height,
+      domainState: newDomainState,
+      signerRecords: newSignerRecords,
+      mempool: [],
+      proposal: undefined,
+    },
+  };
+};

--- a/src/core/encodeRlp.ts
+++ b/src/core/encodeRlp.ts
@@ -1,33 +1,36 @@
-import { concat } from 'uint8arrays'
+import { concat } from 'uint8arrays';
 
 const toUint = (n: number | bigint) => {
-  if (n === 0n || n === 0) return new Uint8Array([0x80])
-  const hex = BigInt(n).toString(16)
-  const bytes = hex.length % 2 ? '0' + hex : hex
-  return new Uint8Array(Buffer.from(bytes, 'hex'))
-}
+  if (n === 0n || n === 0) return new Uint8Array([0x80]);
+  const hex = BigInt(n).toString(16);
+  const bytes = hex.length % 2 ? '0' + hex : hex;
+  return new Uint8Array(Buffer.from(bytes, 'hex'));
+};
 
 const encodeStr = (buf: Uint8Array) =>
-  buf.length === 1 && buf[0] < 0x80 ? buf : concat([new Uint8Array([0x80 + buf.length]), buf])
+  buf.length === 1 && buf[0] < 0x80
+    ? buf
+    : concat([new Uint8Array([0x80 + buf.length]), buf]);
 
 const encodeLen = (len: number, offset: number) => {
-  if (len < 56) return new Uint8Array([offset + len])
-  const b = toUint(len)
-  return concat([new Uint8Array([offset + 55 + b.length]), b])
-}
+  if (len < 56) return new Uint8Array([offset + len]);
+  const b = toUint(len);
+  return concat([new Uint8Array([offset + 55 + b.length]), b]);
+};
 
 export const encodeRlp = (v: unknown): Uint8Array => {
-  if (v === null || v === undefined) return new Uint8Array([0x80])
-  if (typeof v === 'number' || typeof v === 'bigint') return encodeStr(toUint(v))
-  if (typeof v === 'string') return encodeStr(new Uint8Array(Buffer.from(v.slice(2), 'hex')))
-  if (v instanceof Uint8Array) return encodeStr(v)
+  if (v === null || v === undefined) return new Uint8Array([0x80]);
+  if (typeof v === 'number' || typeof v === 'bigint') return encodeStr(toUint(v));
+  if (typeof v === 'string')
+    return encodeStr(new Uint8Array(Buffer.from(v.slice(2), 'hex')));
+  if (v instanceof Uint8Array) return encodeStr(v);
   if (Array.isArray(v)) {
-    const encoded = v.map(encodeRlp)
-    const joined = concat(encoded)
-    return concat([encodeLen(joined.length, 0xc0), joined])
+    const encoded = v.map(encodeRlp);
+    const joined = concat(encoded);
+    return concat([encodeLen(joined.length, 0xc0), joined]);
   }
   const entries = Object.entries(v as Record<string, unknown>).sort(([a], [b]) =>
     a.localeCompare(b),
-  )
-  return encodeRlp(entries.map(([, val]) => val))
-}
+  );
+  return encodeRlp(entries.map(([, val]) => val));
+};

--- a/src/core/hash.ts
+++ b/src/core/hash.ts
@@ -1,23 +1,23 @@
-import keccak256 from 'keccak256'
-import { encodeRlp } from './encodeRlp'
-import { merkle } from './merkle'
-import type { EntityState, Frame, ServerState, EntityTx, Address } from './types'
+import keccak256 from 'keccak256';
+import { encodeRlp } from './encodeRlp';
+import { merkle } from './merkle';
+import type { EntityState, Frame, ServerState, EntityTx, Address } from './types';
 
 /* ---------- helpers ---------- */
 export const getSender = (tx: EntityTx): Address => {
   // TODO: Replace with proper ecrecover when signatures are real
   // For now, extract from sig as per legacy format
-  return tx.sig.slice(0, 42) as Address
-}
+  return tx.sig.slice(0, 42) as Address;
+};
 
 /* ---------- entity‑level hashing ---------- */
 export const hashEntityState = (s: EntityState): Uint8Array =>
-  keccak256(Buffer.from(encodeRlp(s.domainState)))
+  keccak256(Buffer.from(encodeRlp(s.domainState)));
 
 export const sortTransactions = (txs: ReadonlyArray<Frame['txs'][number]>) =>
   [...txs].sort((a, b) =>
     a.nonce === b.nonce ? a.sig.localeCompare(b.sig) : a.nonce < b.nonce ? -1 : 1,
-  )
+  );
 
 export const hashFrame = (f: Frame): Uint8Array => {
   const body = encodeRlp([
@@ -26,17 +26,17 @@ export const hashFrame = (f: Frame): Uint8Array => {
     f.prevStateRoot,
     sortTransactions(f.txs),
     f.postStateRoot,
-  ])
-  return keccak256(Buffer.from(body))
-}
+  ]);
+  return keccak256(Buffer.from(body));
+};
 
 /* ---------- server‑level hashing ---------- */
 export const computeServerRoot = (state: ServerState): Uint8Array => {
   const leaves = [...state.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([, r]) => encodeRlp(r.state))
-  return keccak256(Buffer.from(merkle(leaves)))
-}
+    .map(([, r]) => encodeRlp(r.state));
+  return keccak256(Buffer.from(merkle(leaves)));
+};
 
 export const computeInputsRoot = (batch: Parameters<typeof encodeRlp>[0][]): Uint8Array =>
-  keccak256(Buffer.from(merkle(batch.map(encodeRlp))))
+  keccak256(Buffer.from(merkle(batch.map(encodeRlp))));

--- a/src/core/merkle.ts
+++ b/src/core/merkle.ts
@@ -1,12 +1,12 @@
-import keccak256 from 'keccak256'
-import { concat } from 'uint8arrays'
+import keccak256 from 'keccak256';
+import { concat } from 'uint8arrays';
 export const merkle = (leaves: Uint8Array[]): Uint8Array => {
-  if (leaves.length === 1) return leaves[0]
-  const next: Uint8Array[] = []
+  if (leaves.length === 1) return leaves[0];
+  const next: Uint8Array[] = [];
   for (let i = 0; i < leaves.length; i += 2) {
-    const left = leaves[i]
-    const right = i + 1 < leaves.length ? leaves[i + 1] : left
-    next.push(keccak256(Buffer.from(concat([left, right]))))
+    const left = leaves[i];
+    const right = i + 1 < leaves.length ? leaves[i + 1] : left;
+    next.push(keccak256(Buffer.from(concat([left, right]))));
   }
-  return merkle(next)
-}
+  return merkle(next);
+};

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -1,174 +1,49 @@
-import { verifyAggregate } from './bls'
-import {
-  computeServerRoot,
-  computeInputsRoot,
-  hashEntityState,
-  hashFrame,
-  sortTransactions,
-  getSender,
-} from './hash'
-import type {
-  Address,
-  Command,
-  Frame,
-  Input,
-  Replica,
-  Result,
-  ServerFrame,
-  ServerState,
-  EntityTx,
-} from './types'
-
-/* ---------- helpers ---------- */
-function effectiveWeight(
-  votes: ReadonlyArray<{ signer: string }>,
-  weightMap: Record<string, bigint>,
-): bigint {
-  const seen = new Set<string>()
-  let total = 0n
-  for (const v of votes) {
-    if (seen.has(v.signer)) continue
-    seen.add(v.signer)
-    total += weightMap[v.signer] ?? 0n
-  }
-  return total
-}
-
+import { computeServerRoot, computeInputsRoot } from './hash';
+import * as Cmd from './commands';
+import type { Command, Input, Replica, Result, ServerFrame, ServerState } from './types';
 /* ---------- command handler ---------- */
 const applyCommand = async (
   rep: Replica,
   cmd: Command,
   _now: () => bigint,
 ): Promise<Result<Replica>> => {
-  if (!rep.attached && cmd.type !== 'attachReplica') return { ok: false, error: 'replica-detached' }
+  if (!rep.attached && cmd.type !== 'attachReplica')
+    return { ok: false, error: 'replica-detached' };
 
-  const s = rep.state
+  const s = rep.state;
 
   switch (cmd.type) {
     /* ---------- replica mgmt ---------- */
     case 'attachReplica':
-      return { ok: true, value: { attached: true, state: cmd.snapshot } }
+      return { ok: true, value: { attached: true, state: cmd.snapshot } };
 
     case 'detachReplica':
-      return { ok: true, value: { ...rep, attached: false } }
+      return { ok: true, value: { ...rep, attached: false } };
 
     /* ---------- transaction ---------- */
     case 'addTx': {
-      const signer = cmd.tx.sig.slice(0, 42) as Address
-      const last = s.signerRecords[signer]?.nonce ?? 0n
-      if (cmd.tx.nonce !== last + 1n) return { ok: false, error: 'nonce-out-of-order' }
-      return {
-        ok: true,
-        value: {
-          ...rep,
-          state: {
-            ...s,
-            mempool: [...s.mempool, cmd.tx],
-            signerRecords: { ...s.signerRecords, [signer]: { nonce: cmd.tx.nonce } },
-          },
-        },
-      }
+      const res = Cmd.addTx(s, cmd);
+      return res.ok ? { ok: true, value: { ...rep, state: res.value } } : res;
     }
 
     /* ---------- frame proposal ---------- */
     case 'proposeFrame': {
-      const txs = sortTransactions(s.mempool)
-      const postStateRoot = hashEntityState({ ...s, mempool: [] })
-      const frame: Frame = {
-        ...cmd.header,
-        txs,
-        postStateRoot,
-      }
-      return {
-        ok: true,
-        value: {
-          ...rep,
-          state: { ...s, proposal: { frame, sigs: {} } },
-        },
-      }
+      const { state: ns } = Cmd.proposeFrame(s, cmd);
+      return { ok: true, value: { ...rep, state: ns } };
     }
 
     case 'signFrame': {
-      if (!s.proposal) return { ok: false, error: 'no-proposal' }
-      const addr = cmd.sig.slice(0, 42) as Address
-      if (s.proposal.sigs[addr]) return { ok: false, error: 'dup-sig' }
-      const nonce = (s.signerRecords[addr]?.nonce ?? 0n) + 1n
-      return {
-        ok: true,
-        value: {
-          ...rep,
-          state: {
-            ...s,
-            signerRecords: { ...s.signerRecords, [addr]: { nonce } },
-            proposal: { ...s.proposal, sigs: { ...s.proposal.sigs, [addr]: cmd.sig } },
-          },
-        },
-      }
+      const res = Cmd.signFrame(s, cmd);
+      return res.ok ? { ok: true, value: { ...rep, state: res.value } } : res;
     }
 
     /* ---------- commit ---------- */
     case 'commitFrame': {
-      const { proposal } = s
-      if (!proposal) return { ok: false, error: 'no-proposal' }
-
-      // Check weight before expensive BLS verification
-      const weightMap = Object.fromEntries(
-        s.quorum.members.map((m) => [m.address, m.shares]),
-      ) as Record<string, bigint>
-      const votes = Object.keys(proposal.sigs).map((signer) => ({ signer }))
-      if (effectiveWeight(votes, weightMap) < s.quorum.threshold)
-        return { ok: false, error: 'quorum-not-reached' }
-
-      // Verify BLS aggregate signature
-      const frameHash = hashFrame(cmd.frame)
-      if (!(await verifyAggregate(cmd.hanko, [frameHash], [])))
-        return { ok: false, error: 'invalid-agg-sig' }
-
-      // Apply transactions and update nonces
-      let newDomainState = s.domainState
-      const newSignerRecords = { ...s.signerRecords }
-
-      // Domain reducers dispatch table
-      const domainReducers: Record<string, (state: unknown, tx: EntityTx) => unknown> = {
-        chat: (state, tx) => ({
-          ...(state as { chat?: Array<{ from: string; msg: string }> }),
-          chat: [
-            ...((state as { chat?: Array<{ from: string; msg: string }> }).chat ?? []),
-            { from: getSender(tx), msg: (tx.data as { msg: string }).msg },
-          ],
-        }),
-        // Add other domain reducers here as needed
-      }
-
-      // Process each transaction
-      for (const tx of cmd.frame.txs) {
-        // Apply domain-specific logic
-        const reducer = domainReducers[tx.kind]
-        if (reducer) {
-          newDomainState = reducer(newDomainState, tx)
-        }
-        // Update nonce for replay protection
-        const sender = getSender(tx)
-        newSignerRecords[sender] = { nonce: tx.nonce }
-      }
-
-      return {
-        ok: true,
-        value: {
-          ...rep,
-          state: {
-            ...s,
-            height: cmd.frame.height,
-            domainState: newDomainState,
-            signerRecords: newSignerRecords,
-            mempool: [],
-            proposal: undefined,
-          },
-        },
-      }
+      const res = await Cmd.commitFrame(s, cmd);
+      return res.ok ? { ok: true, value: { ...rep, state: res.value } } : res;
     }
   }
-}
+};
 
 /* ---------- server reducer ---------- */
 export const applyServerFrame = async (
@@ -177,21 +52,21 @@ export const applyServerFrame = async (
   now: () => bigint,
   height: bigint,
 ): Promise<{ next: ServerState; serverFrame: ServerFrame }> => {
-  const next = new Map(st)
-  const rejects: { key: string; err: string }[] = []
+  const next = new Map(st);
+  const rejects: { key: string; err: string }[] = [];
 
   for (const [idx, id, cmd] of batch) {
-    const key = `${idx}:${id}` as const
-    const rep = next.get(key) ?? ({ attached: false, state: cmd.snapshot } as Replica)
-    const res = await applyCommand(rep, cmd, now)
-    if (res.ok) next.set(key, res.value)
-    else rejects.push({ key, err: res.error })
+    const key = `${idx}:${id}` as const;
+    const rep = next.get(key) ?? ({ attached: false, state: cmd.snapshot } as Replica);
+    const res = await applyCommand(rep, cmd, now);
+    if (res.ok) next.set(key, res.value);
+    else rejects.push({ key, err: res.error });
   }
 
-  if (rejects.length) console.warn('rejected commands', rejects)
+  if (rejects.length) console.warn('rejected commands', rejects);
 
-  const root = computeServerRoot(next)
-  const inputsRoot = computeInputsRoot(batch)
+  const root = computeServerRoot(next);
+  const inputsRoot = computeInputsRoot(batch);
 
   return {
     next,
@@ -202,5 +77,5 @@ export const applyServerFrame = async (
       inputsRoot,
       batch,
     },
-  }
-}
+  };
+};

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,56 +1,56 @@
 /* XLN – canonical domain model  v1.4.1‑RC3 */
 
-export type Big = bigint
-export type Address = `0x${string}`
-export type SignerIdx = number
+export type Big = bigint;
+export type Address = `0x${string}`;
+export type SignerIdx = number;
 
 /* ---------- generic helpers ---------- */
-export type Result<T, E = string> = { ok: true; value: T } | { ok: false; error: E }
+export type Result<T, E = string> = { ok: true; value: T } | { ok: false; error: E };
 
 /* ---------- consensus objects ---------- */
 export type EntityTx = {
-  kind: string
-  data: unknown
-  nonce: Big
-  sig: string // signer = sig.slice(0,42)
-}
+  kind: string;
+  data: unknown;
+  nonce: Big;
+  sig: string; // signer = sig.slice(0,42)
+};
 
 export type Quorum = {
-  threshold: Big
-  members: { address: Address; shares: Big }[]
-}
+  threshold: Big;
+  members: { address: Address; shares: Big }[];
+};
 
 export type EntityState = {
-  height: Big
-  quorum: Quorum
-  signerRecords: Record<Address, { nonce: Big }>
-  domainState: unknown
-  mempool: EntityTx[]
-  proposal?: { frame: Frame; sigs: Record<Address, string> }
-}
+  height: Big;
+  quorum: Quorum;
+  signerRecords: Record<Address, { nonce: Big }>;
+  domainState: unknown;
+  mempool: EntityTx[];
+  proposal?: { frame: Frame; sigs: Record<Address, string> };
+};
 
 export type FrameHeader = {
-  height: Big
-  timestamp: Big
-  prevStateRoot: Uint8Array
-}
+  height: Big;
+  timestamp: Big;
+  prevStateRoot: Uint8Array;
+};
 
 export type Frame = FrameHeader & {
-  txs: EntityTx[] // sorted, deterministic
-  postStateRoot: Uint8Array
-}
+  txs: EntityTx[]; // sorted, deterministic
+  postStateRoot: Uint8Array;
+};
 
-export type Replica = { attached: boolean; state: EntityState }
+export type Replica = { attached: boolean; state: EntityState };
 
-export type ServerState = Map<`${SignerIdx}:${string}`, Replica>
+export type ServerState = Map<`${SignerIdx}:${string}`, Replica>;
 
 export type ServerFrame = {
-  height: Big
-  timestamp: Big
-  root: Uint8Array // Merkle‑root of replicas
-  inputsRoot: Uint8Array // Merkle‑root of Input[]
-  batch: Input[]
-}
+  height: Big;
+  timestamp: Big;
+  root: Uint8Array; // Merkle‑root of replicas
+  inputsRoot: Uint8Array; // Merkle‑root of Input[]
+  batch: Input[];
+};
 
 /* ---------- commands & driver input ---------- */
 export type Command =
@@ -59,6 +59,6 @@ export type Command =
   | { type: 'signFrame'; sig: string }
   | { type: 'commitFrame'; frame: Frame; hanko: string }
   | { type: 'attachReplica'; snapshot: EntityState }
-  | { type: 'detachReplica' }
+  | { type: 'detachReplica' };
 
-export type Input = [SignerIdx, string, Command] // signerIndex : entityId
+export type Input = [SignerIdx, string, Command]; // signerIndex : entityId

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { ingest } from './infra/runtime'
+export { ingest } from './infra/runtime';

--- a/src/infra/runtime.ts
+++ b/src/infra/runtime.ts
@@ -1,23 +1,26 @@
-import { performance } from 'node:perf_hooks'
-import { applyServerFrame } from '../core/reducer'
-import type { Input, ServerState } from '../core/types'
+import { performance } from 'node:perf_hooks';
+import { applyServerFrame } from '../core/reducer';
+import type { Input, ServerFrame, ServerState } from '../core/types';
 
-let state: ServerState = new Map()
-let height = 0n
+export type Context = { state: ServerState; height: bigint };
 
-const now = () => BigInt(Math.floor(performance.now()))
+const now = () => BigInt(Math.floor(performance.now()));
 
-export const ingest = async (batch: Input[]) => {
-  height += 1n
-  const { next, serverFrame } = await applyServerFrame(state, batch, now, height)
-  state = next
+export const ingest = async (
+  ctx: Context,
+  batch: Input[],
+): Promise<{ ctx: Context; serverFrame: ServerFrame }> => {
+  const nextHeight = ctx.height + 1n;
+  const { next, serverFrame } = await applyServerFrame(ctx.state, batch, now, nextHeight);
+  const updated = { state: next, height: nextHeight };
 
-  // ---- MVP storage / WAL stub ----
   console.info(
     `⛓️  committed serverFrame #${serverFrame.height} root=${Buffer.from(serverFrame.root)
       .toString('hex')
       .slice(0, 16)}… inputsRoot=${Buffer.from(serverFrame.inputsRoot)
       .toString('hex')
       .slice(0, 16)}…`,
-  )
-}
+  );
+
+  return { ctx: updated, serverFrame };
+};


### PR DESCRIPTION
## Summary
- split command handler into pure helpers
- make runtime ingest stateless
- enforce formatting with a Prettier config

## Testing
- `bun test`
- `bun x prettier --check "src/**/*.{ts,js}"`

------
https://chatgpt.com/codex/tasks/task_b_68677e8b08408323881901cc8fbbc5a3